### PR TITLE
Deprecating `failBuildOnMissingMetadata` and replaced with `failOnError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The following table describes all configuration options:
 |outputDirectory|string|`${project.build.directory}`|Location to place the generated markdown file.|
 |generatedFileName|string|`${project.artifactId}-spring-properties.md`|The name of the generated markdown file.|
 |generatedDocumentationHeader|string|`${project.artifactId} Spring Properties`|The name value for the documentation header (# in markdown).|
-|failBuildOnMissingMetadata|boolean|`true`|Whether to fail the build if the 'spring-configuration-metadata' file cannot be loaded, or does not exist.|
+|failOnError|boolean|`true`|Whether to fail the build if any errors occur during plugin execution. *(Note: When `failBuildOnMissingMetadata` is set to false, this property is currently overridden to false)*|
+|failBuildOnMissingMetadata|boolean|`true`|**Deprecated, use `failOnError` instead**. Whether to fail the build if the 'spring-configuration-metadata' file cannot be loaded, or does not exist. *(Note: When `failOnError` is set to false, this property is now overridden to false)*|
 
 ## Artifact Publication
 All artifacts are published to maven central.

--- a/src/test/resources/missing-metadata-failure-project/pom.xml
+++ b/src/test/resources/missing-metadata-failure-project/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>spring-boot-config-doc-maven-plugin</artifactId>
         <configuration>
           <metadataDirectory>${project.basedir}</metadataDirectory>
-          <failBuildOnMissingMetadata>true</failBuildOnMissingMetadata>
+          <failOnError>true</failOnError>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/missing-metadata-skip-project/pom.xml
+++ b/src/test/resources/missing-metadata-skip-project/pom.xml
@@ -17,7 +17,7 @@
         <artifactId>spring-boot-config-doc-maven-plugin</artifactId>
         <configuration>
           <metadataDirectory>${project.basedir}</metadataDirectory>
-          <failBuildOnMissingMetadata>false</failBuildOnMissingMetadata>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
In preparation for #1, it is preferable to have a catch-all flag that will allow a user to set whether or not the maven build should fail if an error occurs when executing the plugin.